### PR TITLE
Fix missing ios app icon

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -45,7 +45,7 @@
       "type": "image/png"
     },
     {
-      "src": "./icons/icon-180x180.png",
+      "src": "./icons/apple-touch-icon.png",
       "sizes": "180x180",
       "type": "image/png"
     },

--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,7 @@
 		<link rel="apple-touch-icon" sizes="120x120" href="icons/icon-120x120.png" />
 		<link rel="apple-touch-icon" sizes="152x152" href="icons/icon-152x152.png" />
 		<link rel="apple-touch-icon" sizes="167x167" href="icons/icon-167x167.png" />
-		<link rel="apple-touch-icon" sizes="180x180" href="icons/icon-180x180.png" />
+		<link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon.png" />
 		
 		<!-- iOS Splash Screens -->
 		<meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
Fix iOS PWA icon not displaying by correcting 180x180 icon references to `apple-touch-icon.png`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fd3ab8e-2a02-45bb-bf31-a2a368942cc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6fd3ab8e-2a02-45bb-bf31-a2a368942cc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

